### PR TITLE
fix: never serve the original upload for a size-less URL

### DIFF
--- a/src/__tests__/worker.test.ts
+++ b/src/__tests__/worker.test.ts
@@ -5,9 +5,49 @@ import { Env } from '../types';
 const originalWarn = console.warn;
 const originalError = console.error;
 
+const ACCOUNT_HASH = 'mock-account-hash';
+const CACHE_KEY_PREFIX = 'mock-cache-key-prefix';
+
+// Stand-ins for the two kinds of bytes Cloudflare can hand out: the raw upload
+// (full EXIF, GPS included) and a named variant with metadata: none.
+const ORIGINAL_BYTES = 'ORIGINAL-UPLOAD-WITH-EXIF';
+const VARIANT_BYTES = 'STRIPPED-VARIANT';
+
+const variantUrl = (id: string, variant: string) =>
+  `https://imagedelivery.net/${ACCOUNT_HASH}/${id}/${variant}`;
+
 describe('handleImageRequest', () => {
   let mockEnv: Env;
   let mockRequest: Request;
+
+  const fetchMock = () => globalThis.fetch as jest.Mock;
+  const fetchedUrls = () => fetchMock().mock.calls.map(([url]) => String(url));
+  const r2Keys = (method: 'get' | 'put') =>
+    (mockEnv.R2_IMAGES_BUCKET[method] as unknown as jest.Mock).mock.calls.map(([key]) => key);
+
+  /**
+   * Routes every outgoing fetch. The `/blob` endpoint answers with the original
+   * bytes, so any code path that still reaches it would serve them.
+   */
+  const routeFetch = (routes: { variantOk: boolean; uploadOk?: boolean }) => {
+    fetchMock().mockImplementation(async (input: RequestInfo) => {
+      const url = String(input);
+      if (url.endsWith('/blob')) {
+        return new Response(ORIGINAL_BYTES, { status: 200, headers: { 'content-type': 'image/jpeg' } });
+      }
+      if (url.startsWith('https://imagedelivery.net/')) {
+        return routes.variantOk
+          ? new Response(VARIANT_BYTES, { status: 200, headers: { 'content-type': 'image/jpeg' } })
+          : new Response('Not Found', { status: 404 });
+      }
+      if (url.endsWith('/images/v1')) {
+        return routes.uploadOk
+          ? new Response('{"success":true}', { status: 200 })
+          : new Response('{"success":false}', { status: 409 });
+      }
+      throw new Error(`Unexpected fetch in test: ${url}`);
+    });
+  };
 
   beforeAll(() => {
     console.warn = jest.fn();
@@ -27,7 +67,7 @@ describe('handleImageRequest', () => {
       } as unknown as R2Bucket,
       API_TOKEN: 'mock-api-token',
       ACCOUNT_ID: 'mock-account-id',
-      ACCOUNT_HASH: 'mock-account-hash',
+      ACCOUNT_HASH,
       LIVE_SOURCE_URL: 'https://mock-source.com',
       LIVE_PUBLIC_DOMAIN: 'https://mock-public.com',
       KV_STORE: {
@@ -36,11 +76,11 @@ describe('handleImageRequest', () => {
       } as unknown as KVNamespace,
       RATELIMIT_ENABLED: false,
       UPLOAD_FROM_SOURCE: true,
-      CACHE_KEY_PREFIX: 'mock-cache-key-prefix',
+      CACHE_KEY_PREFIX,
     };
 
     mockRequest = new Request('https://worker.dev/test-image-thumbnail.jpg');
-    
+
     // Mock fetch to simulate Cloudflare API response
     globalThis.fetch = jest.fn().mockResolvedValue(new Response('Not Found', { status: 404 }));
   });
@@ -57,9 +97,109 @@ describe('handleImageRequest', () => {
     expect(mockEnv.R2_IMAGES_BUCKET.get).toHaveBeenCalled();
   });
 
-  it('should handle CloudflareApiError when fetching original image fails', async () => {
+  it('should handle CloudflareApiError when the variant is missing and the upload from source fails', async () => {
     const response = await handleImageRequest(mockRequest, mockEnv);
     expect(response.status).toBe(404);
     expect(await response.text()).toContain('Cloudflare API Error: Failed to upload image');
+  });
+
+  it('serves a sized URL from its own named variant and cache key', async () => {
+    routeFetch({ variantOk: true });
+
+    const response = await handleImageRequest(
+      new Request('https://worker.dev/erice-trappani-upload-239571-200x150.jpeg'),
+      mockEnv
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(VARIANT_BYTES);
+    expect(fetchedUrls()).toEqual([variantUrl('erice-trappani-upload-239571', '200x150')]);
+    expect(r2Keys('get')).toEqual([`${CACHE_KEY_PREFIX}/erice-trappani-upload-239571/200x150`]);
+    expect(r2Keys('put')).toEqual([`${CACHE_KEY_PREFIX}/erice-trappani-upload-239571/200x150`]);
+  });
+
+  // climbfinder-api#2559: the size-less URL used to serve the uploaded bytes,
+  // EXIF and GPS included. It must only ever serve a metadata-stripped variant.
+  describe('never serves original bytes', () => {
+    it('serves a size-less URL from the stripped 2048x0 variant', async () => {
+      routeFetch({ variantOk: true });
+
+      const response = await handleImageRequest(
+        new Request('https://worker.dev/erice-trappani-upload-239571.jpeg'),
+        mockEnv
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe(VARIANT_BYTES);
+      expect(fetchedUrls()).toEqual([variantUrl('erice-trappani-upload-239571', '2048x0')]);
+      expect(r2Keys('get')).toEqual([`${CACHE_KEY_PREFIX}/erice-trappani-upload-239571/2048x0`]);
+      expect(r2Keys('put')).toEqual([`${CACHE_KEY_PREFIX}/erice-trappani-upload-239571/2048x0`]);
+    });
+
+    it('does not serve an R2 entry cached under the old original key', async () => {
+      // R2 still holds `<prefix>/<id>/original` entries written by the old worker
+      // with a one-year TTL. Only that key has content here.
+      (mockEnv.R2_IMAGES_BUCKET.get as unknown as jest.Mock).mockImplementation(async (key: string) =>
+        key.endsWith('/original')
+          ? ({ body: ORIGINAL_BYTES, httpMetadata: { contentType: 'image/jpeg' } } as unknown as R2ObjectBody)
+          : null
+      );
+      routeFetch({ variantOk: true });
+
+      const response = await handleImageRequest(
+        new Request('https://worker.dev/erice-trappani-upload-239571.jpeg'),
+        mockEnv
+      );
+
+      expect(response.headers.get('x-r2-cache')).toBe('MISS');
+      expect(await response.text()).toBe(VARIANT_BYTES);
+      expect(r2Keys('get').filter((key) => key.endsWith('/original'))).toEqual([]);
+    });
+
+    // Every branch after a failed variant fetch. The old worker fell back to
+    // `/images/v1/<id>/blob` in all of them, for sized URLs too.
+    it.each([
+      { path: '/erice-trappani-upload-239571.jpeg', upload: false, uploadOk: false },
+      { path: '/erice-trappani-upload-239571-400x300.jpeg', upload: false, uploadOk: false },
+      { path: '/erice-trappani-upload-239571.jpeg', upload: true, uploadOk: true },
+      { path: '/erice-trappani-upload-239571-400x300.jpeg', upload: true, uploadOk: true },
+      { path: '/erice-trappani-upload-239571.jpeg', upload: true, uploadOk: false },
+    ])('never fetches the original when the variant fails ($path, upload=$upload, uploadOk=$uploadOk)', async ({ path, upload, uploadOk }) => {
+      mockEnv.UPLOAD_FROM_SOURCE = upload;
+      routeFetch({ variantOk: false, uploadOk });
+
+      const response = await handleImageRequest(new Request(`https://worker.dev${path}`), mockEnv);
+
+      expect(fetchedUrls().filter((url) => url.endsWith('/blob'))).toEqual([]);
+      expect(fetchedUrls().filter((url) => url.endsWith('/original'))).toEqual([]);
+      expect(response.status).not.toBe(200);
+      expect(await response.text()).not.toContain(ORIGINAL_BYTES);
+      expect(mockEnv.R2_IMAGES_BUCKET.put).not.toHaveBeenCalled();
+    });
+
+    it('returns the variant error status when the variant fails and upload from source is off', async () => {
+      mockEnv.UPLOAD_FROM_SOURCE = false;
+      routeFetch({ variantOk: false });
+
+      const response = await handleImageRequest(
+        new Request('https://worker.dev/erice-trappani-upload-239571.jpeg'),
+        mockEnv
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.text()).toBe('Cloudflare API Error: Failed to fetch image variant');
+    });
+
+    it.each([
+      ['/erice-trappani-upload-239571.jpeg', 'https://mock-public.com/erice-trappani-upload-239571.jpeg'],
+      ['/erice-trappani-upload-239571-400x300.jpeg', 'https://mock-public.com/erice-trappani-upload-239571-400x300.jpeg'],
+    ])('redirects an upload from source back to the requested URL form (%s)', async (path, location) => {
+      routeFetch({ variantOk: false, uploadOk: true });
+
+      const response = await handleImageRequest(new Request(`https://worker.dev${path}`), mockEnv);
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toBe(location);
+    });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,5 +10,9 @@ export const CONFIG: Config = {
   
   // Cache configuration
   DEFAULT_CACHE_TTL: 31536000, // 1 year in seconds
-  
+
+  // Named variant (metadata: none) that serves a size-less URL (`<name>.<ext>`).
+  // The original upload is never served: it carries the uploader's EXIF, GPS
+  // included (climbfinder-api#2559).
+  SIZELESS_VARIANT: '2048x0',
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,27 +30,6 @@ async function uploadToCloudflareImages(env: Env, sourceUrl: string, id: string)
   return response;
 }
 
-/**
- * Fetches the original image from Cloudflare Images.
- * @param {Env} env - The environment variables.
- * @param {string} id - The ID of the image.
- * @returns {Promise<Response>} The image response.
- * @throws {CloudflareApiError} If the fetch fails.
- */
-async function fetchOriginalCloudflareImage(env: Env, id: string): Promise<Response> {
-  const url = `${CONFIG.CLOUDFLARE_API_BASE}/accounts/${env.ACCOUNT_ID}/images/v1/${id}/blob`;
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: { 'Authorization': `Bearer ${env.API_TOKEN}` },
-  });
-
-  if (!response.ok && env.UPLOAD_FROM_SOURCE === false) {
-    throw new CloudflareApiError('Failed to fetch original image', response.status, await response.text());
-  }
-
-  return response;
-}
-
 function parseImageUrl(url: string): ParsedImageUrl | null {
   // Regular expression to match both URL patterns
   const regex = /^\/(.+?)(?:-(\d+)x(\d+))?\.([^\.]+)$/;
@@ -69,14 +48,18 @@ function parseImageUrl(url: string): ParsedImageUrl | null {
       width: parseInt(width) || undefined,
       height: parseInt(height) || undefined,
       extension,
-      variant: width ? `${width}x${height}`.replace(/[^a-zA-Z0-9-_]/g, "") : 'original'
+      variant: `${width}x${height}`.replace(/[^a-zA-Z0-9-_]/g, ""),
+      sizeless: false
     };
   } else {
+    // A size-less URL never maps to the original upload: that carries the
+    // uploader's EXIF, GPS included (climbfinder-api#2559).
     return {
       id: imageId.replace(/[^a-zA-Z0-9-_]/g, "-"),
       originalPath: imageId,
       extension,
-      variant: 'original'
+      variant: CONFIG.SIZELESS_VARIANT,
+      sizeless: true
     };
   }
 }
@@ -99,7 +82,7 @@ export async function handleImageRequest(request: Request, env: Env): Promise<Re
       return new Response('Invalid image URL', { status: 400 });
     }
 
-	const { id, originalPath, extension, variant} = parsedImage;
+	const { id, originalPath, extension, variant, sizeless } = parsedImage;
 
   const file_path = originalPath.replace(/[^a-zA-Z0-9-_\/\.]/g, "-");
   const image_path = file_path?.replace(new RegExp(`\\.(${CLOUDFLARE_IMAGE_EXTENSIONS.join('|')})$`, 'i'), '');
@@ -127,29 +110,28 @@ export async function handleImageRequest(request: Request, env: Env): Promise<Re
       return createImageResponse(cachedImage, true);
     }
 
-    let imageResponse: Response | null = null;
-    if (variant !== '') {
-      imageResponse = await fetch(`${CONFIG.IMAGE_DELIVERY_URL}/${env.ACCOUNT_HASH}/${id}/${variant}`);
-    }    
+    const imageResponse = await fetch(`${CONFIG.IMAGE_DELIVERY_URL}/${env.ACCOUNT_HASH}/${id}/${variant}`);
 
-    if (!imageResponse || !imageResponse.ok) {
-      imageResponse = await fetchOriginalCloudflareImage(env, id);
-    } 
+    if (imageResponse.ok) {
+      await cacheStrategy.set(bucket, cacheKey, imageResponse.clone());
+      return createImageResponse(imageResponse, false);
+    }
 
-    if (env.UPLOAD_FROM_SOURCE && (!imageResponse || !imageResponse.ok)) {
+    // No fallback to the original upload (`/images/v1/<id>/blob`) on a failed
+    // variant: it returns the uploaded bytes unmodified (climbfinder-api#2559).
+    if (env.UPLOAD_FROM_SOURCE) {
       const sourceUrl = `${env.LIVE_SOURCE_URL}/${image_path}.${extension}`;
       const uploadResponse = await uploadToCloudflareImages(env, sourceUrl, id);
 
       if (uploadResponse.ok) {
-        const postfix = variant !== 'original' ? `-${variant}` : '';
+        const postfix = sizeless ? '' : `-${variant}`;
         return Response.redirect(`${env.LIVE_PUBLIC_DOMAIN}/${image_path}${postfix}.${extension}`, 302);
       } else {
         throw new CloudflareApiError('Failed to fetch and upload image', uploadResponse.status, await uploadResponse.text());
       }
     }
 
-    await cacheStrategy.set(bucket, cacheKey, imageResponse.clone());
-    return createImageResponse(imageResponse, false);
+    throw new CloudflareApiError('Failed to fetch image variant', imageResponse.status, await imageResponse.text());
   } catch (error) {
     console.error('Error processing request:', error);
     

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,7 @@ export interface Config {
   RATE_LIMIT_WINDOW: number;
   MAX_REQUESTS_PER_WINDOW: number;
   DEFAULT_CACHE_TTL: number;
+  SIZELESS_VARIANT: string;
 }
 
 export interface R2HTTPMetadata {
@@ -117,4 +118,6 @@ export interface ParsedImageUrl {
   height?: number;
   extension: string;
   variant: string;
+  /** True when the URL had no `-WxH` suffix; `variant` is then CONFIG.SIZELESS_VARIANT. */
+  sizeless: boolean;
 }


### PR DESCRIPTION
## Summary

- **A size-less URL** (`<name>.<ext>`) now resolves to the named variant `2048x0` (metadata: none), set once in `CONFIG.SIZELESS_VARIANT`. It used to resolve to `original`.
- **`fetchOriginalCloudflareImage` (`GET /images/v1/<id>/blob`) is removed.**
  - `/blob` returns the uploaded bytes unmodified, EXIF and GPS included.
  - The worker used to fall back to it after any failed variant fetch, sized ones included.
  - A failed variant now goes to upload-from-source (a 302) or returns the variant's error status.
- **Size-less requests cache under `<prefix>/<id>/2048x0`,** the same key as the `-2048x0` URL. The existing `<prefix>/<id>/original` entries are never read again.
- **An upload-from-source redirect keeps the URL form the client asked for.**

## Tests

The new tests failed 10 of 14 on the previous code. They pin that:
- a size-less URL fetches only the `2048x0` variant, and reads and writes only that R2 key
- an R2 entry under the old `/original` key is not served
- no branch after a failed variant fetches `/blob` or writes to R2

## Consequence

Every size-less asset is served through `2048x0`, so images wider than 2048 px are scaled down on the size-less URL.
