### PR TITLE
fix: accept uppercase and HEIC/heif/jfif image extensions (#151)

### DIFF
--- a/src/__tests__/worker.test.ts
+++ b/src/__tests__/worker.test.ts
@@ -202,4 +202,57 @@ describe('handleImageRequest', () => {
       expect(response.headers.get('location')).toBe(location);
     });
   });
+
+  // #151: climbfinder.cdn stores the extension as uploaded (29,569 `JPG` rows,
+  // plus HEIC/heif/jfif), and the API builds URLs with it as-is. Production
+  // serves all of these today; dng/ARW/zip already fail there.
+  describe('extension check', () => {
+    it.each(['JPG', 'JPEG', 'PNG', 'HEIC', 'heic', 'heif', 'jfif'])(
+      'serves a .%s URL from its variant',
+      async (ext) => {
+        routeFetch({ variantOk: true });
+
+        const response = await handleImageRequest(
+          new Request(`https://worker.dev/zwolse-bos-upload-241443-200x150.${ext}`),
+          mockEnv
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe(VARIANT_BYTES);
+        expect(fetchedUrls()).toEqual([variantUrl('zwolse-bos-upload-241443', '200x150')]);
+      }
+    );
+
+    it.each(['bmp', 'dng', 'ARW', 'zip'])('rejects a .%s URL without fetching anything', async (ext) => {
+      routeFetch({ variantOk: true });
+
+      const response = await handleImageRequest(
+        new Request(`https://worker.dev/zwolse-bos-upload-241443-200x150.${ext}`),
+        mockEnv
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe('Invalid image extension');
+      expect(fetchedUrls()).toEqual([]);
+    });
+
+    it('keeps the extension case in the source URL and the redirect', async () => {
+      // The legacy origin may be case-sensitive: `foo.JPG` is not `foo.jpg` there.
+      routeFetch({ variantOk: false, uploadOk: true });
+
+      const response = await handleImageRequest(
+        new Request('https://worker.dev/zwolse-bos-upload-241443-200x150.JPG'),
+        mockEnv
+      );
+
+      const uploadCall = fetchMock().mock.calls.find(([url]) => String(url).endsWith('/images/v1'));
+      expect((uploadCall?.[1]?.body as FormData).get('url')).toBe(
+        'https://mock-source.com/zwolse-bos-upload-241443.JPG'
+      );
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toBe(
+        'https://mock-public.com/zwolse-bos-upload-241443-200x150.JPG'
+      );
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,8 @@ function parseImageUrl(url: string): ParsedImageUrl | null {
  */
 export async function handleImageRequest(request: Request, env: Env): Promise<Response> {
 
-  const CLOUDFLARE_IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'tif', 'tiff', 'svg'];
+  // heic/heif/jfif: stored by the upload paths and served by Cloudflare Images (#151).
+  const CLOUDFLARE_IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'jfif', 'gif', 'webp', 'avif', 'heic', 'heif', 'tif', 'tiff', 'svg'];
 
   const url = new URL(request.url);
   const parsedImage = parseImageUrl(url.pathname);
@@ -91,7 +92,9 @@ export async function handleImageRequest(request: Request, env: Env): Promise<Re
     return new Response('Missing id parameter', { status: 400 });
   }
 
-  if(!CLOUDFLARE_IMAGE_EXTENSIONS.includes(extension as string)) {
+  // Case-insensitive: stored extensions keep their upload case (`JPG`). Only the
+  // check lowercases; the source URL and redirect keep the case as requested.
+  if(!CLOUDFLARE_IMAGE_EXTENSIONS.includes(extension.toLowerCase())) {
     return new Response('Invalid image extension', { status: 400 });
   }
 


### PR DESCRIPTION
Closes #151.

## Summary

- The extension check is now case-insensitive. Before, `.JPG`, `.JPEG` and `.PNG` got a 400.
- `heic`, `heif` and `jfif` are accepted.
- Only the check lowercases the extension. The source URL and the redirect keep the requested case, because the source origin may be case-sensitive.
- `dng`, `ARW`, `zip` and `.bmp` stay rejected, now with a clear 400.

## Tests

- `npx jest`: 26/26. `npx tsc --noEmit`: exit 0.
- Before the fix, 8 of the new tests failed.
- Mutations:
  - dropping `toLowerCase()` turns 5 tests red
  - dropping `heic`/`heif`/`jfif` turns 4 tests red
